### PR TITLE
chore: Update nock to 9.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "jasmine": "3.1.0",
     "lint-staged": "7.2.0",
     "logdown": "3.2.3",
-    "nock": "9.3.0",
+    "nock": "9.3.2",
     "prettier": "1.13.5",
     "request": "2.87.0",
     "rimraf": "2.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2275,9 +2275,9 @@ nocache@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/nocache/-/nocache-2.0.0.tgz#202b48021a0c4cbde2df80de15a17443c8b43980"
 
-nock@9.3.0:
-  version "9.3.0"
-  resolved "https://registry.yarnpkg.com/nock/-/nock-9.3.0.tgz#4dcfdd37bd249836754d05bbac5a1f05e12e0f16"
+nock@9.3.2:
+  version "9.3.2"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-9.3.2.tgz#f2f52a784a8a33d7496f4ab5b28c3b879091e6d6"
   dependencies:
     chai "^4.1.2"
     debug "^3.1.0"


### PR DESCRIPTION
Closes https://github.com/wireapp/wire-web-ets/pull/19.