### PR TITLE
feat: Send session reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ End-to-end Test Service (ETS) for Wire's test automation suite.
 ```json
 {
   "instanceId": "<string in UUID format>",
+  "messageId": "<string>",
   "name": "<string>"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ End-to-end Test Service (ETS) for Wire's test automation suite.
 
 - [`PUT /api/v1/instance`](#put-apiv1instance)
 - [`GET /api/v1/instance/<instanceId>`](#get-apiv1instanceinstanceid)
-- [`POST /api/v1/instance/<instanceId>/sendText`](#post-apiv1instanceinstanceidsendtext)
+- [`GET /api/v1/instance/<instanceId>/fingerprint`](#get-apiv1instanceinstanceidfingerprint)
 - [`POST /api/v1/instance/<instanceId>/sendImage`](#post-apiv1instanceinstanceidsendimage)
 - [`POST /api/v1/instance/<instanceId>/sendPing`](#post-apiv1instanceinstanceidsendping)
-- [`GET /api/v1/instance/<instanceId>/fingerprint`](#get-apiv1instanceinstanceidfingerprint)
+- [`POST /api/v1/instance/<instanceId>/sendSessionReset`](#post-apiv1instanceinstanceidsendsessionreset)
+- [`POST /api/v1/instance/<instanceId>/sendText`](#post-apiv1instanceinstanceidsendtext)
 - [`POST /api/v1/instance/<instanceId>/typing`](#post-apiv1instanceinstanceidtyping)
 - [`POST /api/v1/instance/<instanceId>/updateText`](#post-apiv1instanceinstanceidupdatetext)
 - [Planned API](#planned-api)
@@ -60,25 +61,14 @@ End-to-end Test Service (ETS) for Wire's test automation suite.
 }
 ```
 
-### `POST /api/v1/instance/<instanceId>/sendText`
-
-#### Request
-
-```json
-{
-  "conversationId": "<string in UUID format>",
-  "messageTimer?": "<number>",
-  "text": "<string>"
-}
-```
+### `GET /api/v1/instance/<instanceId>/fingerprint`
 
 #### Response
 
 ```json
 {
-  "instanceId": "<string in UUID format>",
-  "messageId": "<string>",
-  "name": "<string>"
+  "fingerprint": "<string>",
+  "instanceId": "<string in UUID format>"
 }
 ```
 
@@ -128,14 +118,44 @@ End-to-end Test Service (ETS) for Wire's test automation suite.
 }
 ```
 
-### `GET /api/v1/instance/<instanceId>/fingerprint`
+### `POST /api/v1/instance/<instanceId>/sendSessionReset`
+
+#### Request
+
+```json
+{
+  "conversationId": "<string in UUID format>"
+}
+```
 
 #### Response
 
 ```json
 {
-  "fingerprint": "<string>",
-  "instanceId": "<string in UUID format>"
+  "instanceId": "<string in UUID format>",
+  "name": "<string>"
+}
+```
+
+### `POST /api/v1/instance/<instanceId>/sendText`
+
+#### Request
+
+```json
+{
+  "conversationId": "<string in UUID format>",
+  "messageTimer?": "<number>",
+  "text": "<string>"
+}
+```
+
+#### Response
+
+```json
+{
+  "instanceId": "<string in UUID format>",
+  "messageId": "<string>",
+  "name": "<string>"
 }
 ```
 

--- a/src/main/InstanceService.ts
+++ b/src/main/InstanceService.ts
@@ -71,7 +71,7 @@ class InstanceService {
 
     logger.log('Initializing MemoryEngine...');
 
-    await engine.init('');
+    await engine.init('wire-web-ets');
 
     logger.log(`Creating APIClient with "${backendType.name}" backend ...`);
     const client = new APIClient(new Config(engine, backendType));
@@ -87,6 +87,7 @@ class InstanceService {
 
     try {
       await account.login(LoginData, true, ClientInfo);
+      await account.listen();
     } catch (error) {
       if (error.response && error.response.data && error.response.data.message) {
         throw new Error(`Backend error: ${error.response.data.message}`);
@@ -143,6 +144,18 @@ class InstanceService {
       const key = Object.keys(instance)[0];
       return instance[key];
     });
+  }
+
+  async resetSession(instanceId: string, conversationId: string): Promise<string> {
+    const instance = this.getInstance(instanceId);
+
+    if (instance.account.service) {
+      const sessionResetPayload = instance.account.service.conversation.createSessionReset();
+      const {id: messageId} = await instance.account.service.conversation.send(conversationId, sessionResetPayload);
+      return messageId;
+    } else {
+      throw new Error('Account service not set.');
+    }
   }
 
   async sendText(instanceId: string, conversationId: string, message: string, expireAfterMillis = 0): Promise<string> {

--- a/src/main/routes/instance/index.ts
+++ b/src/main/routes/instance/index.ts
@@ -26,6 +26,7 @@ import clientRoutes from './clientRoutes';
 import confirmationRoutes from './confirmationRoutes';
 import conversationRoutes from './conversationRoutes';
 import mainRoutes from './mainRoutes';
+import sessionRoutes from './sessionRoutes';
 
 const routes = (instanceService: InstanceService): express.Router => {
   const router = express.Router();
@@ -33,8 +34,9 @@ const routes = (instanceService: InstanceService): express.Router => {
   router.use(assetRoutes(instanceService));
   router.use(clientRoutes(instanceService));
   router.use(confirmationRoutes(instanceService));
-  router.use(mainRoutes(instanceService));
   router.use(conversationRoutes(instanceService));
+  router.use(mainRoutes(instanceService));
+  router.use(sessionRoutes(instanceService));
 
   return router;
 };

--- a/src/main/routes/instance/mainRoutes.ts
+++ b/src/main/routes/instance/mainRoutes.ts
@@ -98,6 +98,7 @@ const mainRoutes = (instanceService: InstanceService): express.Router => {
 
   router.get('/api/v1/instances/?', (req, res) => {
     const instances = instanceService.getInstances();
+    console.log({instances});
 
     if (instances.length) {
       return res.json({

--- a/src/main/routes/instance/mainRoutes.ts
+++ b/src/main/routes/instance/mainRoutes.ts
@@ -98,7 +98,6 @@ const mainRoutes = (instanceService: InstanceService): express.Router => {
 
   router.get('/api/v1/instances/?', (req, res) => {
     const instances = instanceService.getInstances();
-    console.log({instances});
 
     if (instances.length) {
       return res.json({

--- a/src/main/routes/instance/sessionRoutes.ts
+++ b/src/main/routes/instance/sessionRoutes.ts
@@ -1,0 +1,60 @@
+/*
+ * Wire
+ * Copyright (C) 2018 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import * as express from 'express';
+import * as Joi from 'joi';
+import InstanceService from '../../InstanceService';
+import joiValidate from '../../middlewares/joiValidate';
+
+const sessionRoutes = (instanceService: InstanceService): express.Router => {
+  const router = express.Router();
+
+  router.post(
+    '/api/v1/instance/:instanceId/sendSessionReset',
+    joiValidate({
+      conversationId: Joi.string()
+        .uuid()
+        .required(),
+    }),
+    async (req: express.Request, res: express.Response) => {
+      const {instanceId = ''}: {instanceId: string} = req.params;
+      const {conversationId}: {conversationId: string} = req.body;
+
+      if (!instanceService.instanceExists(instanceId)) {
+        return res.status(400).json({error: `Instance "${instanceId}" not found.`});
+      }
+
+      try {
+        const messageId = await instanceService.resetSession(instanceId, conversationId);
+        const instanceName = instanceService.getInstance(instanceId).name;
+        return res.json({
+          instanceId,
+          messageId,
+          name: instanceName,
+        });
+      } catch (error) {
+        return res.status(500).json({error: error.message, stack: error.stack});
+      }
+    }
+  );
+
+  return router;
+};
+
+export default sessionRoutes;


### PR DESCRIPTION
* Added the ability to send a session reset
* Fixed differences to the core demo by adding `account.listen()`
* Sorted the API endpoints in the readme