### PR TITLE
fix: Error handlers

### DIFF
--- a/src/main/Server.ts
+++ b/src/main/Server.ts
@@ -25,10 +25,10 @@ import * as http from 'http';
 import {ServerConfig} from './config';
 import InstanceService from './InstanceService';
 import healthCheckRoute from './routes/_health/healthCheckRoute';
-import defaultRoute from './routes/error/defaultRoute';
-import errorRoute from './routes/error/errorRoute';
+import {internalErrorRoute, notFoundRoute} from './routes/error/errorRoutes';
 import InstanceRoutes from './routes/instance/';
 import logRoute from './routes/log/logRoute';
+import mainRoute from './routes/mainRoute';
 
 class Server {
   private app: express.Express;
@@ -54,8 +54,9 @@ class Server {
     this.initAPIRoutes();
     this.app.use(logRoute());
     this.app.use(healthCheckRoute());
-    this.app.use(defaultRoute(this.config));
-    this.app.use(errorRoute(this.config));
+    this.app.use(mainRoute(this.config));
+    this.app.use(notFoundRoute());
+    this.app.use(internalErrorRoute());
   }
 
   initAPIRoutes() {

--- a/src/main/routes/error/errorRoutes.ts
+++ b/src/main/routes/error/errorRoutes.ts
@@ -18,11 +18,26 @@
  */
 
 import * as express from 'express';
-import {ServerConfig} from '../../config';
 
 const router = express.Router();
 
-const defaultRoute = (config: ServerConfig) =>
-  router.get('*', (req, res) => res.json({message: `E2E Test Service v${config.VERSION} ready`}));
+const internalErrorRoute = (): express.ErrorRequestHandler => (err, req, res, next) => {
+  console.error(err.stack);
+  const error = {
+    code: 500,
+    message: 'Internal server error',
+    stack: err.stack,
+  };
+  return res.status(error.code).json(error);
+};
 
-export default defaultRoute;
+const notFoundRoute = () =>
+  router.get('*', (req, res) => {
+    const error = {
+      code: 404,
+      message: 'Not found',
+    };
+    return res.status(error.code).json(error);
+  });
+
+export {internalErrorRoute, notFoundRoute};

--- a/src/main/routes/mainRoute.ts
+++ b/src/main/routes/mainRoute.ts
@@ -18,16 +18,13 @@
  */
 
 import * as express from 'express';
-import {ServerConfig} from '../../config';
+import {ServerConfig} from '../config';
 
-const errorRoute = (config: ServerConfig): express.ErrorRequestHandler => (err, req, res) => {
-  console.error(err.stack);
-  const error = {
-    code: 500,
-    message: 'Internal server error',
-    stack: err.stack,
-  };
-  return res.status(error.code).json(error);
-};
+const router = express.Router();
 
-export default errorRoute;
+const mainRoute = (config: ServerConfig) =>
+  router.get(['/', '/api/v1/?'], (req, res) =>
+    res.json({code: 200, message: `E2E Test Service v${config.VERSION} ready`})
+  );
+
+export default mainRoute;


### PR DESCRIPTION
Fixed the general error handler which was not working correctly. Turns out you need the fourth parameter `next` in the function header, e.g.
```ts
const internalErrorRoute = (): express.ErrorRequestHandler => (err, req, res, next) => {
```
or express will not recognize the function as general error handler.

Furthermore I restricted the main route to `/` and `/api/v1` (instead of `*`) to also add a handler for `404 not found`.