### PR TITLE
fix: Don't check for base64 in file data

### DIFF
--- a/src/main/routes/instance/assetRoutes.ts
+++ b/src/main/routes/instance/assetRoutes.ts
@@ -48,9 +48,7 @@ const assetRoutes = (instanceService: InstanceService): express.Router => {
       conversationId: Joi.string()
         .uuid()
         .required(),
-      data: Joi.string()
-        .base64()
-        .required(),
+      data: Joi.string().required(),
       fileName: Joi.string().required(),
       messageTimer: Joi.number()
         .optional()


### PR DESCRIPTION
This fixes sending large files (> ~10MB) in a POST request.