### PR TITLE
refactor: Add link previews to sendText [BREAKING]

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ End-to-end Test Service (ETS) for Wire's test automation suite.
 - [`POST /api/v1/instance/<instanceId>/markEphemeralRead`](#post-apiv1instanceinstanceidmarkephemeralread)
 - [`POST /api/v1/instance/<instanceId>/sendFile`](#post-apiv1instanceinstanceidsendfile)
 - [`POST /api/v1/instance/<instanceId>/sendImage`](#post-apiv1instanceinstanceidsendimage)
-- [`POST /api/v1/instance/<instanceId>/sendLinkPreview`](#post-apiv1instanceinstanceidsendlinkpreview)
 - [`POST /api/v1/instance/<instanceId>/sendLocation`](#post-apiv1instanceinstanceidsendlocation)
 - [`POST /api/v1/instance/<instanceId>/sendPing`](#post-apiv1instanceinstanceidsendping)
 - [`POST /api/v1/instance/<instanceId>/sendReaction`](#post-apiv1instanceinstanceidsendreaction)
@@ -332,42 +331,6 @@ End-to-end Test Service (ETS) for Wire's test automation suite.
 }
 ```
 
-### `POST /api/v1/instance/<instanceId>/sendLinkPreview`
-
-#### Request
-
-```json
-{
-  "conversationId": "<string>",
-  "image?": {
-    "data": "<string>",
-    "height": "<number>",
-    "type": "<string>",
-    "width": "<number>"
-  },
-  "permanentUrl?": "<string>",
-  "summary?": "<string>",
-  "text": "<string>",
-  "title?": "<string>",
-  "url": "<string>",
-  "urlOffset": "<number>",
-  "tweet?": {
-    "author": "<string>",
-    "username": "<string>"
-  }
-}
-```
-
-#### Response
-
-```json
-{
-  "instanceId": "<string in UUID format>",
-  "messageId": "<string>",
-  "name": "<string>"
-}
-```
-
 ### `POST /api/v1/instance/<instanceId>/sendLocation`
 
 #### Request
@@ -463,6 +426,23 @@ End-to-end Test Service (ETS) for Wire's test automation suite.
 ```json
 {
   "conversationId": "<string in UUID format>",
+  "linkPreview?": {
+    "image?": {
+      "data": "<string>",
+      "height": "<number>",
+      "type": "<string>",
+      "width": "<number>"
+    },
+    "permanentUrl?": "<string>",
+    "summary?": "<string>",
+    "title?": "<string>",
+    "url": "<string>",
+    "urlOffset": "<number>",
+    "tweet?": {
+      "author?": "<string>",
+      "username?": "<string>"
+    }
+  },
   "messageTimer?": "<number>",
   "text": "<string>"
 }
@@ -506,7 +486,6 @@ End-to-end Test Service (ETS) for Wire's test automation suite.
 {
   "conversationId": "<string in UUID format>",
   "firstMessageId": "<string in UUID format>",
-  "text": "<string>",
   "linkPreview?": {
     "image?": {
       "data": "<string>",
@@ -516,7 +495,6 @@ End-to-end Test Service (ETS) for Wire's test automation suite.
     },
     "permanentUrl?": "<string>",
     "summary?": "<string>",
-    "text": "<string>",
     "title?": "<string>",
     "url": "<string>",
     "urlOffset": "<number>",
@@ -524,7 +502,8 @@ End-to-end Test Service (ETS) for Wire's test automation suite.
       "author?": "<string>",
       "username?": "<string>"
     }
-  }
+  },
+  "text": "<string>"
 }
 ```
 

--- a/src/main/routes/instance/assetRoutes.ts
+++ b/src/main/routes/instance/assetRoutes.ts
@@ -17,12 +17,7 @@
  *
  */
 
-import {
-  FileContent,
-  FileMetaDataContent,
-  ImageContent,
-  LinkPreviewContent,
-} from '@wireapp/core/dist/conversation/content/';
+import {FileContent, FileMetaDataContent, ImageContent} from '@wireapp/core/dist/conversation/content/';
 import * as express from 'express';
 import * as Joi from 'joi';
 import InstanceService from '../../InstanceService';
@@ -43,42 +38,6 @@ export interface ImageMessageRequest extends AssetMessageRequest {
   height: number;
   width: number;
 }
-
-export interface LinkPreviewRequest {
-  image?: {
-    data: string;
-    height: number;
-    type: string;
-    width: number;
-  };
-  permanentUrl: string;
-  summary?: string;
-  title?: string;
-  tweet?: {
-    author?: string;
-    username?: string;
-  };
-  url: string;
-  urlOffset: number;
-}
-
-export const validateLinkPreview = {
-  image: Joi.object({
-    data: Joi.string().required(),
-    height: Joi.number().required(),
-    type: Joi.string().required(),
-    width: Joi.number().required(),
-  }).optional(),
-  permanentUrl: Joi.string().required(),
-  summary: Joi.string().optional(),
-  title: Joi.string().optional(),
-  tweet: Joi.object({
-    author: Joi.string().optional(),
-    username: Joi.string().optional(),
-  }).optional(),
-  url: Joi.string().required(),
-  urlOffset: Joi.number().required(),
-};
 
 const assetRoutes = (instanceService: InstanceService): express.Router => {
   const router = express.Router();
@@ -153,63 +112,6 @@ const assetRoutes = (instanceService: InstanceService): express.Router => {
         const data = Buffer.from(base64Data, 'base64');
         const image: ImageContent = {data, height, type, width};
         const messageId = await instanceService.sendImage(instanceId, conversationId, image, messageTimer);
-        const instanceName = instanceService.getInstance(instanceId).name;
-        return res.json({
-          instanceId,
-          messageId,
-          name: instanceName,
-        });
-      } catch (error) {
-        return res.status(500).json({error: error.message, stack: error.stack});
-      }
-    }
-  );
-
-  router.post(
-    '/api/v1/instance/:instanceId/sendLinkPreview/?',
-    joiValidate({
-      ...validateLinkPreview,
-      conversationId: Joi.string().required(),
-      text: Joi.string().required(),
-    }),
-    async (req: express.Request, res: express.Response) => {
-      const {instanceId = ''}: {instanceId: string} = req.params;
-      const {
-        conversationId,
-        image,
-        permanentUrl,
-        summary,
-        text,
-        title,
-        tweet,
-        url,
-        urlOffset,
-      }: LinkPreviewRequest & {conversationId: string; text: string} = req.body;
-
-      if (!instanceService.instanceExists(instanceId)) {
-        return res.status(400).json({error: `Instance "${instanceId}" not found.`});
-      }
-
-      const linkPreview: LinkPreviewContent = {
-        permanentUrl,
-        summary,
-        title,
-        tweet,
-        url,
-        urlOffset,
-      };
-
-      try {
-        let imageContent: ImageContent | undefined;
-
-        if (image) {
-          const data = Buffer.from(image.data, 'base64');
-          imageContent = {data, height: image.height, type: image.type, width: image.width};
-
-          linkPreview.image = imageContent;
-        }
-
-        const messageId = await instanceService.sendLinkPreview(instanceId, conversationId, text, linkPreview);
         const instanceName = instanceService.getInstance(instanceId).name;
         return res.json({
           instanceId,


### PR DESCRIPTION
This PR will
* remove `/sendLinkPreview`.
* add link previews to `/sendText`.

Reason:

With the upcoming [PR for mentions](https://github.com/wireapp/wire-web-ets/pull/309) we get more additional data in normal text messages. It would be too much overhead and maintenance work to create an endpoint for both of them. Instead we just use one endpoint and make mentions and link previews optional in the POST request.