### PR TITLE
chore: Let Travis use the latest yarn version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,7 @@ node_js:
 
 notifications:
   email: false
+
+before_install:
+  - curl https://yarnpkg.com/install.sh -sSfL | bash -s --
+  - export PATH="${HOME}/.yarn/bin:${PATH}"


### PR DESCRIPTION
The latest version of `yarn` introduced some changes to the lock file format. To avoid further merge conflicts on every dependabot PR, we let Travis use the latest `yarn` version.