### PR TITLE
fix: Read string as hex data

### DIFF
--- a/src/main/routes/instance/conversationRoutes.ts
+++ b/src/main/routes/instance/conversationRoutes.ts
@@ -24,7 +24,7 @@ import * as Joi from 'joi';
 
 import InstanceService from '../../InstanceService';
 import joiValidate from '../../middlewares/joiValidate';
-import {stringToUint8Array} from '../../utils';
+import {hexToUint8Array} from '../../utils';
 
 export interface MessageRequest {
   conversationId: string;
@@ -397,7 +397,7 @@ const conversationRoutes = (instanceService: InstanceService): express.Router =>
       if (quote) {
         quoteContent = {
           quotedMessageId: quote.quotedMessageId,
-          quotedMessageSha256: stringToUint8Array(quote.quotedMessageSha256),
+          quotedMessageSha256: hexToUint8Array(quote.quotedMessageSha256),
         };
       }
 
@@ -539,7 +539,7 @@ const conversationRoutes = (instanceService: InstanceService): express.Router =>
       if (quote) {
         quoteContent = {
           quotedMessageId: quote.quotedMessageId,
-          quotedMessageSha256: stringToUint8Array(quote.quotedMessageSha256),
+          quotedMessageSha256: hexToUint8Array(quote.quotedMessageSha256),
         };
       }
 

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -36,9 +36,9 @@ function formatUptime(uptime: number): string {
   return moment.utc(duration).format('HH:mm:ss');
 }
 
-function stringToUint8Array(inputString: string): Uint8Array {
-  const buffer = Buffer.from(inputString);
+function hexToUint8Array(inputString: string): Uint8Array {
+  const buffer = Buffer.from(inputString, 'hex');
   return new Uint8Array(buffer);
 }
 
-export {fileIsReadable, formatDate, formatUptime, stringToUint8Array};
+export {fileIsReadable, formatDate, formatUptime, hexToUint8Array};


### PR DESCRIPTION
If a `Buffer` is not created with the 'hex' parameter, it will read the string as UTF-8 data and not as hex string.

```
> Buffer.from('ab12')
<Buffer 61 62 31 32>

> Buffer.from('ab12', 'hex')
<Buffer ab 12>
```