### PR TITLE
feat: Read receipts (WEBFOUND-57)

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,8 @@ Type can be `0` (`NONE`), `1` (`AVAILABLE`), `2` (`AWAY`), `3` (`BUSY`).
 
 ### `POST /api/v1/instance/<instanceId>/sendEphemeralConfirmationDelivered`
 
+#### Request
+
 ```json
 {
   "conversationId": "<string in UUID format>",

--- a/README.md
+++ b/README.md
@@ -61,9 +61,11 @@ yarn start
 - [`POST /api/v1/instance/<instanceId>/delete`](#post-apiv1instanceinstanceiddelete)
 - [`POST /api/v1/instance/<instanceId>/deleteEverywhere`](#post-apiv1instanceinstanceiddeleteeverywhere)
 - [`POST /api/v1/instance/<instanceId>/getMessages`](#post-apiv1instanceinstanceidgetmessages)
-- [`POST /api/v1/instance/<instanceId>/markEphemeralRead`](#post-apiv1instanceinstanceidmarkephemeralread)
 - [`POST /api/v1/instance/<instanceId>/mute`](#post-apiv1instanceinstanceidmute)
-- [`POST /api/v1/instance/<instanceId>/sendConfirmation`](#post-apiv1instanceinstanceidsendconfirmation)
+- [`POST /api/v1/instance/<instanceId>/sendConfirmationDelivered`](#post-apiv1instanceinstanceidsendconfirmationdelivered)
+- [`POST /api/v1/instance/<instanceId>/sendConfirmationRead`](#post-apiv1instanceinstanceidsendconfirmationread)
+- [`POST /api/v1/instance/<instanceId>/sendEphemeralConfirmationDelivered`](#post-apiv1instanceinstanceidsendephemeralconfirmationdelivered)
+- [`POST /api/v1/instance/<instanceId>/sendEphemeralConfirmationRead`](#post-apiv1instanceinstanceidsendephemeralconfirmationread)
 - [`POST /api/v1/instance/<instanceId>/sendFile`](#post-apiv1instanceinstanceidsendfile)
 - [`POST /api/v1/instance/<instanceId>/sendImage`](#post-apiv1instanceinstanceidsendimage)
 - [`POST /api/v1/instance/<instanceId>/sendLocation`](#post-apiv1instanceinstanceidsendlocation)
@@ -325,32 +327,14 @@ Type can be `0` (`NONE`), `1` (`AVAILABLE`), `2` (`AWAY`), `3` (`BUSY`).
 ]
 ```
 
-### `POST /api/v1/instance/<instanceId>/markEphemeralRead`
-
-```json
-{
-  "conversationId": "<string in UUID format>",
-  "messageId": "<string in UUID format>"
-}
-```
-
-#### Response
-
-```json
-{
-  "instanceId": "<string in UUID format>",
-  "name": "<string>"
-}
-```
-
 ### `POST /api/v1/instance/<instanceId>/mute`
 
 #### Request
 
 ```json
 {
-  "mute": "<boolean>",
-  "conversationId": "<string in UUID format>"
+  "conversationId": "<string in UUID format>",
+  "mute": "<boolean>"
 }
 ```
 
@@ -363,14 +347,74 @@ Type can be `0` (`NONE`), `1` (`AVAILABLE`), `2` (`AWAY`), `3` (`BUSY`).
 }
 ```
 
-### `POST /api/v1/instance/<instanceId>/sendConfirmation`
+### `POST /api/v1/instance/<instanceId>/sendConfirmationDelivered`
 
 #### Request
 
 ```json
 {
   "conversationId": "<string in UUID format>",
-  "messageId": "<string in UUID format>"
+  "firstMessageId": "<string in UUID format>",
+  "moreMessageIds?": "<Array of strings in UUID format>"
+}
+```
+
+#### Response
+
+```json
+{
+  "instanceId": "<string in UUID format>",
+  "name": "<string>"
+}
+```
+
+### `POST /api/v1/instance/<instanceId>/sendConfirmationRead`
+
+#### Request
+
+```json
+{
+  "conversationId": "<string in UUID format>",
+  "firstMessageId": "<string in UUID format>",
+  "moreMessageIds?": "<Array of strings in UUID format>"
+}
+```
+
+#### Response
+
+```json
+{
+  "instanceId": "<string in UUID format>",
+  "name": "<string>"
+}
+```
+
+### `POST /api/v1/instance/<instanceId>/sendEphemeralConfirmationDelivered`
+
+```json
+{
+  "conversationId": "<string in UUID format>",
+  "firstMessageId": "<string in UUID format>",
+  "moreMessageIds?": "<Array of strings in UUID format>"
+}
+```
+
+#### Response
+
+```json
+{
+  "instanceId": "<string in UUID format>",
+  "name": "<string>"
+}
+```
+
+### `POST /api/v1/instance/<instanceId>/sendEphemeralConfirmationRead`
+
+```json
+{
+  "conversationId": "<string in UUID format>",
+  "firstMessageId": "<string in UUID format>",
+  "moreMessageIds?": "<Array of strings in UUID format>"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ Type can be `0` (`NONE`), `1` (`AVAILABLE`), `2` (`AWAY`), `3` (`BUSY`).
 [
   {
     "content?": {
+      "expectsReadConfirmation?": "<boolean>",
       "text": "<string>"
     },
     "conversation": "<string in UUID format>",
@@ -435,6 +436,7 @@ Type can be `0` (`NONE`), `1` (`AVAILABLE`), `2` (`AWAY`), `3` (`BUSY`).
 {
   "conversationId": "<string in UUID format>",
   "data": "<string in base64 format>",
+  "expectsReadConfirmation?": "<boolean>",
   "fileName": "<string>",
   "messageTimer?": "<number>",
   "type": "<string>"
@@ -459,6 +461,7 @@ Type can be `0` (`NONE`), `1` (`AVAILABLE`), `2` (`AWAY`), `3` (`BUSY`).
 {
   "conversationId": "<string in UUID format>",
   "data": "<string in base64 format>",
+  "expectsReadConfirmation?": "<boolean>",
   "height": "<number>",
   "messageTimer?": "<number>",
   "type": "<string>",
@@ -483,6 +486,7 @@ Type can be `0` (`NONE`), `1` (`AVAILABLE`), `2` (`AWAY`), `3` (`BUSY`).
 ```json
 {
   "conversationId": "<string>",
+  "expectsReadConfirmation?": "<boolean>",
   "latitude": "<number>",
   "locationName": "<string>",
   "longitude": "<number>",
@@ -508,6 +512,7 @@ Type can be `0` (`NONE`), `1` (`AVAILABLE`), `2` (`AWAY`), `3` (`BUSY`).
 ```json
 {
   "conversationId": "<string in UUID format>",
+  "expectsReadConfirmation?": "<boolean>",
   "messageTimer?": "<number>"
 }
 ```
@@ -571,6 +576,7 @@ Type can be `0` (`NONE`), `1` (`AVAILABLE`), `2` (`AWAY`), `3` (`BUSY`).
 ```json
 {
   "conversationId": "<string in UUID format>",
+  "expectsReadConfirmation?": "<boolean>",
   "linkPreview?": {
     "image?": {
       "data": "<string in base64 format>",
@@ -595,11 +601,11 @@ Type can be `0` (`NONE`), `1` (`AVAILABLE`), `2` (`AWAY`), `3` (`BUSY`).
       "userId": "<string in UUID format>"
     }
   ],
+  "messageTimer?": "<number>",
   "quote?": {
     "quotedMessageId": "<string in UUID format>",
     "quotedMessageSha256": "<string in SHA256 format>"
   },
-  "messageTimer?": "<number>",
   "text": "<string>"
 }
 ```
@@ -641,6 +647,7 @@ Type can be `0` (`NONE`), `1` (`AVAILABLE`), `2` (`AWAY`), `3` (`BUSY`).
 ```json
 {
   "conversationId": "<string in UUID format>",
+  "expectsReadConfirmation?": "<boolean>",
   "firstMessageId": "<string in UUID format>",
   "linkPreview?": {
     "image?": {

--- a/README.md
+++ b/README.md
@@ -413,6 +413,8 @@ Type can be `0` (`NONE`), `1` (`AVAILABLE`), `2` (`AWAY`), `3` (`BUSY`).
 
 ### `POST /api/v1/instance/<instanceId>/sendEphemeralConfirmationRead`
 
+#### Request
+
 ```json
 {
   "conversationId": "<string in UUID format>",

--- a/docs/swagger.md
+++ b/docs/swagger.md
@@ -672,15 +672,16 @@ opensource@wire.com
 
 ### Message
 
-| Name         | Type               | Description | Required |
-| ------------ | ------------------ | ----------- | -------- |
-| content      | object             |             | No       |
-| conversation | string (uuid)      |             | Yes      |
-| from         | string (uuid)      |             | Yes      |
-| id           | string (uuid)      |             | Yes      |
-| messageTimer | string (number)    |             | Yes      |
-| state        | undefined (string) |             | Yes      |
-| type         | undefined (string) |             | Yes      |
+| Name                    | Type               | Description | Required |
+| ----------------------- | ------------------ | ----------- | -------- |
+| content                 | object             |             | No       |
+| conversation            | string (uuid)      |             | Yes      |
+| expectsReadConfirmation | boolean            |             | No       |
+| from                    | string (uuid)      |             | Yes      |
+| id                      | string (uuid)      |             | Yes      |
+| messageTimer            | string (number)    |             | Yes      |
+| state                   | undefined (string) |             | Yes      |
+| type                    | undefined (string) |             | Yes      |
 
 ### NotFound
 
@@ -691,11 +692,12 @@ opensource@wire.com
 
 ### TextMessage
 
-| Name           | Type                        | Description | Required |
-| -------------- | --------------------------- | ----------- | -------- |
-| conversationId | string (uuid)               |             | No       |
-| linkPreview    | [LinkPreview](#linkpreview) |             | No       |
-| mentions       | [ [Mention](#mention) ]     |             | No       |
-| messageTimer   | string (number)             |             | No       |
-| quote          | object                      |             | No       |
-| text           | string                      |             | No       |
+| Name                    | Type                        | Description | Required |
+| ----------------------- | --------------------------- | ----------- | -------- |
+| conversationId          | string (uuid)               |             | No       |
+| expectsReadConfirmation | boolean                     |             | No       |
+| linkPreview             | [LinkPreview](#linkpreview) |             | No       |
+| mentions                | [ [Mention](#mention) ]     |             | No       |
+| messageTimer            | string (number)             |             | No       |
+| quote                   | object                      |             | No       |
+| text                    | string                      |             | No       |

--- a/docs/swagger.md
+++ b/docs/swagger.md
@@ -270,28 +270,6 @@ opensource@wire.com
 | 200  |             | [ [Message](#message) ] |
 | 404  | Not found   | [NotFound](#notfound)   |
 
-### /instance/{instanceId}/markEphemeralRead
-
----
-
-##### **_POST_**
-
-**Summary:** Mark an ephemeral message as read
-
-**Parameters**
-
-| Name       | Located in | Description              | Required | Schema        |
-| ---------- | ---------- | ------------------------ | -------- | ------------- |
-| instanceId | path       | ID of instance to return | Yes      | string (uuid) |
-| body       | body       |                          | Yes      | object        |
-
-**Responses**
-
-| Code | Description | Schema                              |
-| ---- | ----------- | ----------------------------------- |
-| 200  |             | [InstanceAndName](#instanceandname) |
-| 404  | Not found   | [NotFound](#notfound)               |
-
 ### /instance/{instanceId}/mute
 
 ---
@@ -314,13 +292,79 @@ opensource@wire.com
 | 200  |             | [InstanceAndName](#instanceandname) |
 | 404  | Not found   | [NotFound](#notfound)               |
 
-### /instance/{instanceId}/sendConfirmation
+### /instance/{instanceId}/sendConfirmationDelivered
 
 ---
 
 ##### **_POST_**
 
-**Summary:** Send a receive confirmation for a message
+**Summary:** Send a delivery confirmation for a message
+
+**Parameters**
+
+| Name       | Located in | Description              | Required | Schema        |
+| ---------- | ---------- | ------------------------ | -------- | ------------- |
+| instanceId | path       | ID of instance to return | Yes      | string (uuid) |
+| body       | body       |                          | Yes      | object        |
+
+**Responses**
+
+| Code | Description | Schema                              |
+| ---- | ----------- | ----------------------------------- |
+| 200  |             | [InstanceAndName](#instanceandname) |
+| 404  | Not found   | [NotFound](#notfound)               |
+
+### /instance/{instanceId}/sendConfirmationRead
+
+---
+
+##### **_POST_**
+
+**Summary:** Send a read confirmation for a message
+
+**Parameters**
+
+| Name       | Located in | Description              | Required | Schema        |
+| ---------- | ---------- | ------------------------ | -------- | ------------- |
+| instanceId | path       | ID of instance to return | Yes      | string (uuid) |
+| body       | body       |                          | Yes      | object        |
+
+**Responses**
+
+| Code | Description | Schema                              |
+| ---- | ----------- | ----------------------------------- |
+| 200  |             | [InstanceAndName](#instanceandname) |
+| 404  | Not found   | [NotFound](#notfound)               |
+
+### /instance/{instanceId}/sendEphemeralConfirmationDelivered
+
+---
+
+##### **_POST_**
+
+**Summary:** Send a delivery confirmation for an ephemeral message
+
+**Parameters**
+
+| Name       | Located in | Description              | Required | Schema        |
+| ---------- | ---------- | ------------------------ | -------- | ------------- |
+| instanceId | path       | ID of instance to return | Yes      | string (uuid) |
+| body       | body       |                          | Yes      | object        |
+
+**Responses**
+
+| Code | Description | Schema                              |
+| ---- | ----------- | ----------------------------------- |
+| 200  |             | [InstanceAndName](#instanceandname) |
+| 404  | Not found   | [NotFound](#notfound)               |
+
+### /instance/{instanceId}/sendEphemeralConfirmationRead
+
+---
+
+##### **_POST_**
+
+**Summary:** Send a read confirmation for an ephemeral message
 
 **Parameters**
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@types/helmet": "0.0.42",
     "@types/joi": "14.0.0",
     "@types/node": "10.12.9",
-    "@wireapp/core": "7.3.8",
+    "@wireapp/core": "8.0.0",
     "@wireapp/lru-cache": "3.0.17",
     "body-parser": "1.18.3",
     "compression": "1.7.3",

--- a/swagger.yml
+++ b/swagger.yml
@@ -135,6 +135,8 @@ definitions:
       conversation:
         format: uuid
         type: string
+      expectsReadConfirmation:
+        type: boolean
       from:
         format: uuid
         type: string
@@ -172,6 +174,8 @@ definitions:
       conversationId:
         format: uuid
         type: string
+      expectsReadConfirmation:
+        type: boolean
       linkPreview:
         $ref: '#/definitions/LinkPreview'
       mentions:
@@ -793,6 +797,8 @@ paths:
               data:
                 format: base64
                 type: string
+              expectsReadConfirmation:
+                type: boolean
               fileName:
                 type: string
               messageTimer:
@@ -842,6 +848,8 @@ paths:
               data:
                 format: base64
                 type: string
+              expectsReadConfirmation:
+                type: boolean
               height:
                 format: number
                 type: string
@@ -892,6 +900,8 @@ paths:
               conversationId:
                 format: uuid
                 type: string
+              expectsReadConfirmation:
+                type: boolean
               latitude:
                 format: number
                 type: string
@@ -945,6 +955,8 @@ paths:
               conversationId:
                 format: uuid
                 type: string
+              expectsReadConfirmation:
+                type: boolean
               messageTimer:
                 format: number
                 type: string

--- a/swagger.yml
+++ b/swagger.yml
@@ -578,43 +578,6 @@ paths:
       summary: Get all messages
       tags:
         - Instance
-  /instance/{instanceId}/markEphemeralRead:
-    post:
-      operationId: markEphemeralRead
-      parameters:
-        - description: ID of instance to return
-          format: uuid
-          in: path
-          name: instanceId
-          required: true
-          type: string
-        - description: ''
-          in: body
-          name: body
-          required: true
-          schema:
-            properties:
-              conversationId:
-                format: uuid
-                type: string
-              messageId:
-                format: uuid
-                type: string
-            type: object
-      produces:
-        - application/json
-      responses:
-        200:
-          description: ''
-          schema:
-            $ref: '#/definitions/InstanceAndName'
-        404:
-          description: Not found
-          schema:
-            $ref: '#/definitions/NotFound'
-      summary: Mark an ephemeral message as read
-      tags:
-        - Instance
   /instance/{instanceId}/mute:
     post:
       operationId: muteConversation
@@ -651,9 +614,95 @@ paths:
       summary: Mute a conversation
       tags:
         - Instance
-  /instance/{instanceId}/sendConfirmation:
+  /instance/{instanceId}/sendConfirmationDelivered:
     post:
-      operationId: sendConfirmation
+      operationId: sendConfirmationDelivered
+      parameters:
+        - description: ID of instance to return
+          format: uuid
+          in: path
+          name: instanceId
+          required: true
+          type: string
+        - description: ''
+          in: body
+          name: body
+          required: true
+          schema:
+            properties:
+              conversationId:
+                format: uuid
+                type: string
+              firstMessageId:
+                format: uuid
+                type: string
+              moreMessageIds:
+                format: uuid
+                type: string
+            required:
+              - conversationId
+              - firstMessageId
+            type: object
+      produces:
+        - application/json
+      responses:
+        200:
+          description: ''
+          schema:
+            $ref: '#/definitions/InstanceAndName'
+        404:
+          description: Not found
+          schema:
+            $ref: '#/definitions/NotFound'
+      summary: Send a delivery confirmation for a message
+      tags:
+        - Instance
+  /instance/{instanceId}/sendConfirmationRead:
+    post:
+      operationId: sendConfirmationRead
+      parameters:
+        - description: ID of instance to return
+          format: uuid
+          in: path
+          name: instanceId
+          required: true
+          type: string
+        - description: ''
+          in: body
+          name: body
+          required: true
+          schema:
+            properties:
+              conversationId:
+                format: uuid
+                type: string
+              firstMessageId:
+                format: uuid
+                type: string
+              moreMessageIds:
+                format: uuid
+                type: string
+            required:
+              - conversationId
+              - firstMessageId
+            type: object
+      produces:
+        - application/json
+      responses:
+        200:
+          description: ''
+          schema:
+            $ref: '#/definitions/InstanceAndName'
+        404:
+          description: Not found
+          schema:
+            $ref: '#/definitions/NotFound'
+      summary: Send a read confirmation for a message
+      tags:
+        - Instance
+  /instance/{instanceId}/sendEphemeralConfirmationDelivered:
+    post:
+      operationId: sendEphemeralConfirmationDelivered
       parameters:
         - description: ID of instance to return
           format: uuid
@@ -685,7 +734,44 @@ paths:
           description: Not found
           schema:
             $ref: '#/definitions/NotFound'
-      summary: Send a receive confirmation for a message
+      summary: Send a delivery confirmation for an ephemeral message
+      tags:
+        - Instance
+  /instance/{instanceId}/sendEphemeralConfirmationRead:
+    post:
+      operationId: sendEphemeralConfirmationRead
+      parameters:
+        - description: ID of instance to return
+          format: uuid
+          in: path
+          name: instanceId
+          required: true
+          type: string
+        - description: ''
+          in: body
+          name: body
+          required: true
+          schema:
+            properties:
+              conversationId:
+                format: uuid
+                type: string
+              messageId:
+                format: uuid
+                type: string
+            type: object
+      produces:
+        - application/json
+      responses:
+        200:
+          description: ''
+          schema:
+            $ref: '#/definitions/InstanceAndName'
+        404:
+          description: Not found
+          schema:
+            $ref: '#/definitions/NotFound'
+      summary: Send a read confirmation for an ephemeral message
       tags:
         - Instance
   /instance/{instanceId}/sendFile:

--- a/yarn.lock
+++ b/yarn.lock
@@ -386,17 +386,18 @@
   resolved "https://registry.yarnpkg.com/@wireapp/cbor/-/cbor-3.0.107.tgz#52647ae59a52f78995f6bfdd986c58f597ac6100"
   integrity sha512-A5AzGWNghavKrZfubZbpMDqyWg1klAgo4NwaUon9hKy6mHRBTk323rjqhfQSup3bPcEvJUKG5Z9gHtVMO3vxAQ==
 
-"@wireapp/core@7.3.8":
-  version "7.3.8"
-  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-7.3.8.tgz#ea323a1d6b633143209844796efdbacb0b512bed"
-  integrity sha512-kgCd6NriuntvSt4QFw9+jGUng8kHj8idlDIT0voezE6KGhyKvba8xj9Cf5P0SJAWPmpO0MyowClJH2vvgxfpIA==
+"@wireapp/core@8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-8.0.0.tgz#7aebb168e58b8373506bf1c4d84403b503f447d8"
+  integrity sha512-/FTTITomlQsvx3iIXaaj+o2YnvVREPGthF2cN43fgBGCOCL9KpJHFXazEy8rkvONUbo8dGppfnnnz36Dq16AXg==
   dependencies:
     "@types/node" "10.12.10"
     "@wireapp/api-client" "3.2.7"
     "@wireapp/cryptobox" "9.0.29"
-    "@wireapp/protocol-messaging" "1.22.1"
+    "@wireapp/protocol-messaging" "1.23.0"
     "@wireapp/store-engine" "1.1.7"
     bazinga64 "5.3.30"
+    hash.js "1.1.5"
     logdown "3.2.7"
     protobufjs "6.8.8"
     pure-uuid "1.5.5"
@@ -442,10 +443,10 @@
     ed2curve "0.2.1"
     libsodium-wrappers-sumo "0.7.3"
 
-"@wireapp/protocol-messaging@1.22.1":
-  version "1.22.1"
-  resolved "https://registry.yarnpkg.com/@wireapp/protocol-messaging/-/protocol-messaging-1.22.1.tgz#2cdfde7ce51487fd38a52c2cce1ec2f4c100372e"
-  integrity sha512-yw95stCSbaBcAU8iXBXle5xDpJecpbhO6GEeMV4huA2hlNTtZIe3i+V4zpUu9QpeXQhIAKTnJMVDZh3TQN9lKw==
+"@wireapp/protocol-messaging@1.23.0":
+  version "1.23.0"
+  resolved "https://registry.yarnpkg.com/@wireapp/protocol-messaging/-/protocol-messaging-1.23.0.tgz#aa26b96eb0933c9b95d34d9502098d7c582036a0"
+  integrity sha512-/B+xvw/3EmSGE4Ej63FOzNSxWnCPdNdrzetVY0BNiVdj3sioW8+EPcOltjgI2PPDTDKZnTu9+cnsJclYx7HA2Q==
   dependencies:
     protobufjs "6.8.8"
 
@@ -2149,6 +2150,14 @@ has@^1.0.1, has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hash.js@1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.5.tgz#e38ab4b85dfb1e0c40fe9265c0e9b54854c23812"
+  integrity sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==
+  dependencies:
+    inherits "^2.0.3"
+    minimalistic-assert "^1.0.1"
+
 helmet-crossdomain@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/helmet-crossdomain/-/helmet-crossdomain-0.3.0.tgz#707e2df930f13ad61f76ed08e1bb51ab2b2e85fa"
@@ -2305,7 +2314,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
@@ -3079,6 +3088,11 @@ mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
+
+minimalistic-assert@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
+  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
 minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
This closes #546.

<details>
<summary>New endpoints</summary>

#### `POST /api/v1/instance/<instanceId>/sendConfirmationDelivered`

**Request**

```json
{
  "conversationId": "<string in UUID format>",
  "firstMessageId": "<string in UUID format>",
  "moreMessageIds?": "<Array of strings in UUID format>"
}
```

**Response**

```json
{
  "instanceId": "<string in UUID format>",
  "name": "<string>"
}
```

#### `POST /api/v1/instance/<instanceId>/sendConfirmationRead`

**Request**

```json
{
  "conversationId": "<string in UUID format>",
  "firstMessageId": "<string in UUID format>",
  "moreMessageIds?": "<Array of strings in UUID format>"
}
```

**Response**

```json
{
  "instanceId": "<string in UUID format>",
  "name": "<string>"
}
```

#### `POST /api/v1/instance/<instanceId>/sendEphemeralConfirmationDelivered`

**Request**

```json
{
  "conversationId": "<string in UUID format>",
  "firstMessageId": "<string in UUID format>",
  "moreMessageIds?": "<Array of strings in UUID format>"
}
```

**Response**

```json
{
  "instanceId": "<string in UUID format>",
  "name": "<string>"
}
```

#### `POST /api/v1/instance/<instanceId>/sendEphemeralConfirmationRead`

**Request**

```json
{
  "conversationId": "<string in UUID format>",
  "firstMessageId": "<string in UUID format>",
  "moreMessageIds?": "<Array of strings in UUID format>"
}
```

**Response**

```json
{
  "instanceId": "<string in UUID format>",
  "name": "<string>"
}
```
</details>

<details>
<summary>Removed endpoints</summary>

* `POST /api/v1/instance/<instanceId>/sendConfirmation`
* `POST /api/v1/instance/<instanceId>/markEphemeralRead`
</details>

<details>
<summary>Updated endpoints</summary>

* `POST /api/v1/instance/<instanceId>/getMessages`
  * response: has now `expectsReadConfirmation` (`boolean`, optional) in `content`.
* `POST /api/v1/instance/<instanceId>/sendFile`
  * request: now accepts `expectsReadConfirmation` (`boolean`, optional).
* `POST /api/v1/instance/<instanceId>/sendImage`
  * request: now accepts `expectsReadConfirmation` (`boolean`, optional).
* `POST /api/v1/instance/<instanceId>/sendLocation`
  * request: now accepts `expectsReadConfirmation` (`boolean`, optional).
* `POST /api/v1/instance/<instanceId>/sendPing`
  * request: now accepts `expectsReadConfirmation` (`boolean`, optional).
* `POST /api/v1/instance/<instanceId>/sendText`
  * request: now accepts `expectsReadConfirmation` (`boolean`, optional).
* `POST /api/v1/instance/<instanceId>/updateText`
  * request: now accepts `expectsReadConfirmation` (`boolean`, optional).
</details>