### PR TITLE
fix: Set Swagger port automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ yarn start
 ## API documentation (Swagger)
 
 - [swagger.md](./docs/swagger.md)
-- Swagger UI is available at `/api-docs` when the ETS is running.
+- Swagger UI is available at `/swagger-ui` when the ETS is running.
 
 ## API documentation (old)
 

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -26,11 +26,11 @@ import * as http from 'http';
 import {ServerConfig} from './config';
 import InstanceService from './InstanceService';
 import healthCheckRoute from './routes/_health/healthCheckRoute';
-import {initSwaggerRoute} from './routes/api-docs/swaggerRoute';
 import {internalErrorRoute, notFoundRoute} from './routes/error/errorRoutes';
 import InstanceRoutes from './routes/instance/';
 import logRoute from './routes/log/logRoute';
 import mainRoute from './routes/mainRoute';
+import {initSwaggerRoute} from './routes/swagger-ui/swaggerRoute';
 
 class Server {
   private app: express.Express;
@@ -64,7 +64,7 @@ class Server {
     this.app.use(logRoute());
     this.app.use(healthCheckRoute());
     this.app.use(mainRoute(this.config));
-    initSwaggerRoute(this.app);
+    initSwaggerRoute(this.app, this.config);
     this.app.use(notFoundRoute());
     this.app.use(internalErrorRoute());
   }

--- a/src/routes/swagger-ui/swaggerRoute.ts
+++ b/src/routes/swagger-ui/swaggerRoute.ts
@@ -21,10 +21,17 @@ import * as express from 'express';
 import * as path from 'path';
 import * as swaggerUi from 'swagger-ui-express';
 import * as yaml from 'yamljs';
+import {ServerConfig} from '../../config';
 
 const yamlFile = path.join(__dirname, '..', '..', '..', 'swagger.yml');
 const swaggerDocument = yaml.load(yamlFile);
 
-export function initSwaggerRoute(app: express.Express) {
-  app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
+export function initSwaggerRoute(app: express.Express, config: ServerConfig) {
+  app.use(
+    '/swagger-ui',
+    swaggerUi.serve,
+    swaggerUi.setup(swaggerDocument, {
+      host: `localhost:${config.PORT_HTTP}`,
+    })
+  );
 }

--- a/src/routes/swagger-ui/swaggerRoute.ts
+++ b/src/routes/swagger-ui/swaggerRoute.ts
@@ -27,11 +27,9 @@ const yamlFile = path.join(__dirname, '..', '..', '..', 'swagger.yml');
 const swaggerDocument = yaml.load(yamlFile);
 
 export function initSwaggerRoute(app: express.Express, config: ServerConfig) {
-  app.use(
-    '/swagger-ui',
-    swaggerUi.serve,
-    swaggerUi.setup(swaggerDocument, {
-      host: `localhost:${config.PORT_HTTP}`,
-    })
-  );
+  const swaggerUiOptions = {
+    host: `localhost:${config.PORT_HTTP}`,
+  };
+
+  app.use('/swagger-ui', swaggerUi.serve, swaggerUi.setup(swaggerDocument, swaggerUiOptions));
 }

--- a/swagger.yml
+++ b/swagger.yml
@@ -193,7 +193,6 @@ definitions:
       text:
         type: string
     type: object
-host: localhost
 info:
   contact:
     email: opensource@wire.com
@@ -558,8 +557,6 @@ paths:
             properties:
               conversationId:
                 format: uuid
-                type: string
-              name:
                 type: string
             type: object
       produces:


### PR DESCRIPTION
This PR will
* set the Swagger UI port to the current port the ETS is running on
* move the URL for the Swagger UI to `/swagger-ui`.
* remove an unnecessary key for the Swagger docs in `/getMessages`