### PR TITLE
chore: Use approximate version for @types/node

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@types/express": "4.16.1",
     "@types/helmet": "0.0.43",
     "@types/joi": "14.3.3",
-    "@types/node": "12.0.0",
+    "@types/node": "~10",
     "@wireapp/core": "10.0.3",
     "@wireapp/lru-cache": "3.1.10",
     "body-parser": "1.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -355,7 +355,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@12.0.0":
+"@types/node@*":
   version "12.0.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.0.tgz#d11813b9c0ff8aaca29f04cbc12817f4c7d656e5"
   integrity sha512-Jrb/x3HT4PTJp6a4avhmJCDEVrPdqLfl3e8GGMbpkGGdwAV5UGlIs4vVEfsHHfylZVOKZWpOqmqFH8CbfOZ6kg==
@@ -374,6 +374,11 @@
   version "8.10.40"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.40.tgz#4314888d5cd537945d73e9ce165c04cc550144a4"
   integrity sha512-RRSjdwz63kS4u7edIwJUn8NqKLLQ6LyqF/X4+4jp38MBT3Vwetewi2N4dgJEshLbDwNgOJXNYoOwzVZUSSLhkQ==
+
+"@types/node@~10":
+  version "10.14.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.6.tgz#9cbfcb62c50947217f4d88d4d274cc40c22625a9"
+  integrity sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
This should always be in sync with [`.travis.yml`](https://github.com/wireapp/wire-web-ets/blob/069659f327f79accd0be6af47946337455aa1b14/.travis.yml#L25).