### PR TITLE
feat: Add option for custom backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,7 @@ yarn start
 **Notes**:
 
 - You can either set `backend` or `customBackend`. If you set neither, the "staging" backend will be used. If you set both, `backend` takes the precedence.
-
-- The device class can be set to any string if `backend` is unset and `customBackend` is set.
+- `deviceClass` can be set to any string if `backend` is unset and `customBackend` is set.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -178,11 +178,22 @@ yarn start
 
 ### `PUT /api/v1/instance`
 
+#### `BackendData`
+
+```json
+{
+  "name": "<string>",
+  "rest": "<string in URI format>",
+  "ws": "<string in URI format>"
+}
+```
+
 #### Request
 
 ```json
 {
-  "backend": "<'prod'|'production'|'staging'>",
+  "backend?": "<'prod'|'production'|'staging'>",
+  "customBackend?": "<BackendData>",
   "deviceClass?": "<'desktop'|'phone'|'tablet'>",
   "deviceLabel?": "<string>",
   "deviceName?": "<string>",
@@ -211,11 +222,22 @@ yarn start
 
 ### `DELETE /api/v1/clients`
 
+#### `BackendData`
+
+```json
+{
+  "name": "<string>",
+  "rest": "<string in URI format>",
+  "ws": "<string in URI format>"
+}
+```
+
 #### Request
 
 ```json
 {
-  "backend": "<'prod'|'production'|'staging'>",
+  "backend?": "<'prod'|'production'|'staging'>",
+  "customBackend?": "<BackendData>",
   "email": "<string in email format>",
   "password": "<string>"
 }
@@ -629,14 +651,14 @@ Confirmation type can be `0` (Delivered) or `1` (Read).
       "type": "<string>",
       "width": "<number>"
     },
-    "permanentUrl?": "<string>",
+    "permanentUrl?": "<string in URI format>",
     "summary?": "<string>",
     "title?": "<string>",
     "tweet?": {
       "author?": "<string>",
       "username?": "<string>"
     },
-    "url": "<string>",
+    "url": "<string in URI format>",
     "urlOffset": "<number>"
   },
   "mentions?": [
@@ -701,14 +723,14 @@ Confirmation type can be `0` (Delivered) or `1` (Read).
       "type": "<string>",
       "width": "<number>"
     },
-    "permanentUrl?": "<string>",
+    "permanentUrl?": "<string in URI format>",
     "summary?": "<string>",
     "title?": "<string>",
     "tweet?": {
       "author?": "<string>",
       "username?": "<string>"
     },
-    "url": "<string>",
+    "url": "<string in URI format>",
     "urlOffset": "<number>"
   },
   "mentions?": [

--- a/README.md
+++ b/README.md
@@ -190,6 +190,12 @@ yarn start
 
 #### Request
 
+**Notes**:
+
+- You can either set `backend` or `customBackend`. If you set neither, the "staging" backend will be used. If you set both, `backend` takes the precedence.
+
+- The device class can be set to any string if `backend` is unset and `customBackend` is set.
+
 ```json
 {
   "backend?": "<'prod'|'production'|'staging'>",
@@ -233,6 +239,12 @@ yarn start
 ```
 
 #### Request
+
+**Notes**:
+
+- You can either set `backend` or `customBackend`. If you set neither, the "staging" backend will be used. If you set both, `backend` takes the precedence.
+
+- The device class can be set to any string if `backend` is unset and `customBackend` is set.
 
 ```json
 {

--- a/docs/swagger.md
+++ b/docs/swagger.md
@@ -593,19 +593,28 @@ Get all instances
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 |  | object |
+| 200 |  | [Instance](#instance) |
 | 404 | Not found | [NotFoundError](#notfounderror) |
 
 ### Models
 
+
+#### BackendData
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| name | string |  | Yes |
+| rest | string |  | Yes |
+| ws | string |  | Yes |
 
 #### BasicLogin
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | backend | string |  | No |
-| email | string (email) |  | No |
-| password | password |  | No |
+| customBackend | [BackendData](#backenddata) |  | No |
+| email | string (email) |  | Yes |
+| password | password |  | Yes |
 
 #### Client
 
@@ -677,7 +686,8 @@ Get all instances
 | from | string (uuid) |  | Yes |
 | id | string (uuid) |  | Yes |
 | messageTimer | string (number) |  | Yes |
-| state | undefined (string) |  | Yes |
+| state | string |  | Yes |
+| timestamp | string |  | Yes |
 | type | undefined (string) |  | Yes |
 
 #### NotFoundError

--- a/docs/swagger.md
+++ b/docs/swagger.md
@@ -6,8 +6,8 @@ End-to-end Test Service (ETS) for Wire's test automation suite.
 ### Terms of service
 https://wire.com/legal/
 
-**Contact information:**  
-opensource@wire.com  
+**Contact information:**
+opensource@wire.com
 
 **License:** [GPL-3.0](https://github.com/wireapp/wire-web-ets/blob/master/LICENSE)
 
@@ -21,6 +21,7 @@ Delete all clients
 ##### Description:
 
 **Notes**:
+
 You can either set `backend` or `customBackend`. If you set neither, the "staging" backend will be used. If you set both, `backend` takes the precedence.
 
 ##### Parameters
@@ -664,9 +665,15 @@ Get all instances
 
 #### Login
 
+**Notes**:
+
+You can either set `backend` or `customBackend`. If you set neither, the "staging" backend will be used. If you set both, `backend` takes the precedence.
+
+`deviceClass` can be set to any string if `backend` is unset and `customBackend` is set.
+
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| Login |  |  |  |
+| Login |  | **Notes**: You can either set `backend` or `customBackend`. If you set neither, the "staging" backend will be used. If you set both, `backend` takes the precedence. `deviceClass` can be set to any string if `backend` is unset and `customBackend` is set. |  |
 
 #### Mention
 

--- a/docs/swagger.md
+++ b/docs/swagger.md
@@ -20,7 +20,8 @@ Delete all clients
 
 ##### Description:
 
-
+**Notes**:
+You can either set `backend` or `customBackend`. If you set neither, the "staging" backend will be used. If you set both, `backend` takes the precedence.
 
 ##### Parameters
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@types/helmet": "0.0.43",
     "@types/joi": "14.3.3",
     "@types/node": "~10",
-    "@wireapp/core": "10.2.2",
+    "@wireapp/core": "10.2.4",
     "@wireapp/lru-cache": "3.1.12",
     "body-parser": "1.19.0",
     "celebrate": "10.0.0",

--- a/src/InstanceService.ts
+++ b/src/InstanceService.ts
@@ -256,8 +256,6 @@ export class InstanceService {
       model: options.deviceName || `E2E Test Server v${version}`,
     };
 
-    console.log('ClientInfo', ClientInfo);
-
     logger.log(`[${formatDate()}] Logging in ...`);
 
     try {

--- a/src/InstanceService.ts
+++ b/src/InstanceService.ts
@@ -256,6 +256,8 @@ export class InstanceService {
       model: options.deviceName || `E2E Test Server v${version}`,
     };
 
+    console.log('ClientInfo', ClientInfo);
+
     logger.log(`[${formatDate()}] Logging in ...`);
 
     try {

--- a/src/InstanceService.ts
+++ b/src/InstanceService.ts
@@ -76,7 +76,7 @@ export interface Instance {
 export interface InstanceCreationOptions {
   backend?: string;
   customBackend?: BackendData;
-  deviceClass?: ClientClassification.DESKTOP | ClientClassification.PHONE | ClientClassification.TABLET;
+  deviceClass?: string;
   deviceLabel?: string;
   deviceName?: string;
   instanceName?: string;
@@ -187,15 +187,16 @@ export class InstanceService {
   private parseBackend(backend?: string | BackendData): BackendData {
     if (typeof backend === 'string') {
       switch (backend) {
-        case 'staging': {
-          return APIClient.BACKEND.STAGING;
+        case 'production':
+        case 'prod': {
+          return APIClient.BACKEND.PRODUCTION;
         }
         default: {
-          return APIClient.BACKEND.PRODUCTION;
+          return APIClient.BACKEND.STAGING;
         }
       }
     } else if (typeof backend === 'undefined') {
-      return APIClient.BACKEND.PRODUCTION;
+      return APIClient.BACKEND.STAGING;
     } else {
       return backend;
     }
@@ -250,7 +251,7 @@ export class InstanceService {
     const account = new Account(client);
 
     const ClientInfo: ClientInfo = {
-      classification: options.deviceClass || ClientClassification.DESKTOP,
+      classification: (options.deviceClass as any) || ClientClassification.DESKTOP,
       cookieLabel: 'default',
       label: options.deviceLabel,
       model: options.deviceName || `E2E Test Server v${version}`,

--- a/src/routes/instance/conversationRoutes.ts
+++ b/src/routes/instance/conversationRoutes.ts
@@ -54,7 +54,7 @@ export interface LinkPreviewRequest {
     type: string;
     width: number;
   };
-  permanentUrl: string;
+  permanentUrl?: string;
   summary?: string;
   title?: string;
   tweet?: {
@@ -104,14 +104,27 @@ const validateLinkPreview = {
     type: Joi.string().required(),
     width: Joi.number().required(),
   }).optional(),
-  permanentUrl: Joi.string().required(),
-  summary: Joi.string().optional(),
-  title: Joi.string().optional(),
+  permanentUrl: Joi.string()
+    .uri()
+    .allow('')
+    .optional(),
+  summary: Joi.string()
+    .allow('')
+    .optional(),
+  title: Joi.string()
+    .allow('')
+    .optional(),
   tweet: Joi.object({
-    author: Joi.string().optional(),
-    username: Joi.string().optional(),
+    author: Joi.string()
+      .allow('')
+      .optional(),
+    username: Joi.string()
+      .allow('')
+      .optional(),
   }).optional(),
-  url: Joi.string().required(),
+  url: Joi.string()
+    .uri()
+    .required(),
   urlOffset: Joi.number().required(),
 };
 
@@ -323,7 +336,9 @@ export const conversationRoutes = (instanceService: InstanceService): express.Ro
           .required(),
         expectsReadConfirmation: Joi.boolean().default(false),
         latitude: Joi.number().required(),
-        locationName: Joi.string().optional(),
+        locationName: Joi.string()
+          .allow('')
+          .optional(),
         longitude: Joi.number().required(),
         messageTimer: Joi.number()
           .default(0)

--- a/swagger.json
+++ b/swagger.json
@@ -362,7 +362,7 @@
     "/clients": {
       "delete": {
         "consumes": ["application/json"],
-        "description": "",
+        "description": "**Notes**:\nYou can either set `backend` or `customBackend`. If you set neither, the \"staging\" backend will be used. If you set both, `backend` takes the precedence.",
         "operationId": "deleteAllClients",
         "parameters": [
           {

--- a/swagger.json
+++ b/swagger.json
@@ -1,11 +1,29 @@
 {
   "basePath": "/api/v1",
   "definitions": {
+    "BackendData": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "rest": {
+          "type": "string"
+        },
+        "ws": {
+          "type": "string"
+        }
+      },
+      "required": ["name", "rest", "ws"],
+      "type": "object"
+    },
     "BasicLogin": {
       "properties": {
         "backend": {
           "enum": ["staging", "prod", "production"],
           "type": "string"
+        },
+        "customBackend": {
+          "$ref": "#/definitions/BackendData"
         },
         "email": {
           "format": "email",
@@ -16,6 +34,7 @@
           "type": "string"
         }
       },
+      "required": ["email", "password"],
       "type": "object"
     },
     "Client": {
@@ -185,7 +204,7 @@
           "type": "object"
         }
       ],
-      "required": ["backend", "email", "password"]
+      "required": ["email", "password"]
     },
     "Mention": {
       "properties": {
@@ -1839,10 +1858,7 @@
           "200": {
             "description": "",
             "schema": {
-              "additionalProperties": {
-                "$ref": "#/definitions/Instance"
-              },
-              "type": "object"
+              "$ref": "#/definitions/Instance"
             }
           },
           "404": {

--- a/swagger.json
+++ b/swagger.json
@@ -204,6 +204,7 @@
           "type": "object"
         }
       ],
+      "description": "**Notes**:\n\nYou can either set `backend` or `customBackend`. If you set neither, the \"staging\" backend will be used. If you set both, `backend` takes the precedence.\n`deviceClass` can be set to any string if `backend` is unset and `customBackend` is set.",
       "required": ["email", "password"]
     },
     "Mention": {
@@ -362,7 +363,7 @@
     "/clients": {
       "delete": {
         "consumes": ["application/json"],
-        "description": "**Notes**:\nYou can either set `backend` or `customBackend`. If you set neither, the \"staging\" backend will be used. If you set both, `backend` takes the precedence.",
+        "description": "**Notes**:\n\nYou can either set `backend` or `customBackend`. If you set neither, the \"staging\" backend will be used. If you set both, `backend` takes the precedence.",
         "operationId": "deleteAllClients",
         "parameters": [
           {

--- a/yarn.lock
+++ b/yarn.lock
@@ -421,10 +421,10 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-2.3.5.tgz#9da44ed75571999b65c37b60c9b2b88db54c585d"
   integrity sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==
 
-"@wireapp/api-client@4.3.1":
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/@wireapp/api-client/-/api-client-4.3.1.tgz#a79548b3419bd5903984ab8f0bf3ff1796d824b1"
-  integrity sha512-DN84ZbdV8BrWdCo5iMUoHcuNOftx3UFpgnKMbYaeyeVFZi1nxo3NxNgMDLXGQTAYjsmDLLHAs6SpwHgTD+c/7Q==
+"@wireapp/api-client@4.4.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@wireapp/api-client/-/api-client-4.4.0.tgz#8fdfd337b56479651cba36d82cd60207e64af67e"
+  integrity sha512-tOfkX7l7zyz7efWpsSWtlfJqzOWipjTQuhdodkwcMLES3bQOTc0V5nPlE9fOAcb6oLGdMfId7iDpQ4luz78BDw==
   dependencies:
     "@types/node" "~10"
     "@types/spark-md5" "3.0.1"
@@ -443,13 +443,13 @@
   resolved "https://registry.yarnpkg.com/@wireapp/cbor/-/cbor-4.0.2.tgz#c8af71b1c0f6edf2f100799231dab706640401f0"
   integrity sha512-wXepr0e7Eivw4GqgzkJ5h8xja2WBr/YebTBsTGQVRWaSxff64MAE65dYFDbPipc2yjCckGPOGHLQv5d+K0is0Q==
 
-"@wireapp/core@10.2.2":
-  version "10.2.2"
-  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-10.2.2.tgz#7e0c4328eef641f4a30b377c9e131a9b787adbfd"
-  integrity sha512-Wv3tNNCvB/QsPfdDRllgc/ayPzYbFkbzSwY2ryICVDZQRf3OH1LqM9Rph5PsvyrYNeohaepBlOGJo27tUpyBZQ==
+"@wireapp/core@10.2.4":
+  version "10.2.4"
+  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-10.2.4.tgz#de08bf9d35944ce473dabd50db25b58f85293954"
+  integrity sha512-dnEVeXaxjKFDKxfPboiVol5qsMHaISGsHyFNCvKjFBCzhlLi61M6mTO63HiJ5ph5fs92tJFJO4lpshO04DZ4Hw==
   dependencies:
     "@types/node" "~10"
-    "@wireapp/api-client" "4.3.1"
+    "@wireapp/api-client" "4.4.0"
     "@wireapp/cryptobox" "10.1.2"
     "@wireapp/protocol-messaging" "1.23.0"
     "@wireapp/store-engine" "2.1.2"


### PR DESCRIPTION
Old instance creation payload example:
```json
{
  "backend": "staging",
  "email": "user@example.com",
  "password": "my-password",
}
```

New instance creation payload example:
```json
{
  "customBackend": {
    "name": "my-backend",
    "rest": "https://my-backend.io",
    "ws":  "ws://my-backend.io",
  },
  "email": "user@example.com",
  "password": "my-password",
}
```