### PR TITLE
fix: Remove useless descriptions from responses

### DIFF
--- a/src/instance/InstanceController.ts
+++ b/src/instance/InstanceController.ts
@@ -67,7 +67,6 @@ export class InstanceController {
   @Put()
   @ApiOperation({summary: 'Create a new instance.'})
   @ApiResponse({
-    description: 'The instance was successfully created.',
     schema: {
       example: {
         instanceId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
@@ -94,7 +93,6 @@ export class InstanceController {
   @Delete(':instanceId')
   @ApiOperation({summary: 'Delete an instance.'})
   @ApiResponse({
-    description: 'The instance was successfully deleted.',
     schema: {
       example: {},
     },
@@ -122,7 +120,6 @@ export class InstanceController {
   @Get(':instanceId')
   @ApiOperation({summary: 'Get information about an instance.'})
   @ApiResponse({
-    description: 'The instance was successfully deleted.',
     schema: {
       example: {
         backend: 'string',
@@ -161,7 +158,6 @@ export class InstanceController {
   @Post(':instanceId/archive')
   @ApiOperation({summary: 'Archive a conversation.'})
   @ApiResponse({
-    description: 'The conversation archived status has been updated.',
     schema: {
       example: {
         instanceId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
@@ -200,7 +196,6 @@ export class InstanceController {
   @Post(':instanceId/availability')
   @ApiOperation({summary: "Set a user's availability."})
   @ApiResponse({
-    description: "The user's availability has been updated.",
     schema: {
       example: {
         instanceId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
@@ -243,7 +238,6 @@ export class InstanceController {
   @Post(':instanceId/clear')
   @ApiOperation({summary: 'Clear a conversation.'})
   @ApiResponse({
-    description: 'The conversation has been cleared.',
     schema: {
       example: {
         instanceId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
@@ -282,7 +276,6 @@ export class InstanceController {
   @Get(':instanceId/clients')
   @ApiOperation({summary: 'Get all clients of an instance.'})
   @ApiResponse({
-    description: 'The list of all clients.',
     schema: {
       example: [
         {
@@ -324,7 +317,6 @@ export class InstanceController {
   @Post(':instanceId/delete')
   @ApiOperation({summary: 'Delete a message locally.'})
   @ApiResponse({
-    description: 'The message was deleted locally.',
     schema: {
       example: {
         instanceId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
@@ -363,7 +355,6 @@ export class InstanceController {
   @Post(':instanceId/deleteEverywhere')
   @ApiOperation({summary: 'Delete a message for everyone.'})
   @ApiResponse({
-    description: 'The message was deleted for everyone.',
     schema: {
       example: {
         instanceId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
@@ -402,7 +393,6 @@ export class InstanceController {
   @Get(':instanceId/fingerprint')
   @ApiOperation({summary: "Get the fingerprint from the instance's client."})
   @ApiResponse({
-    description: 'The fingerprint of the client.',
     schema: {
       example: {
         fingerprint: 'string',
@@ -437,7 +427,6 @@ export class InstanceController {
   @Post(':instanceId/getMessages')
   @ApiOperation({summary: 'Get all messages.'})
   @ApiResponse({
-    description: 'All messages.',
     schema: {
       example: [
         {
@@ -501,7 +490,6 @@ export class InstanceController {
   @Post(':instanceId/mute')
   @ApiOperation({summary: 'Mute a conversation.'})
   @ApiResponse({
-    description: 'The conversation muted status has been updated.',
     schema: {
       example: {
         instanceId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
@@ -540,7 +528,6 @@ export class InstanceController {
   @Post(':instanceId/sendConfirmationDelivered')
   @ApiOperation({summary: 'Send a delivery confirmation for a message.'})
   @ApiResponse({
-    description: 'The delivery confirmation has been sent.',
     schema: {
       example: {
         instanceId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
@@ -579,7 +566,6 @@ export class InstanceController {
   @Post(':instanceId/sendConfirmationRead')
   @ApiOperation({summary: 'Send a read confirmation for a message.'})
   @ApiResponse({
-    description: 'The read confirmation has been sent.',
     schema: {
       example: {
         instanceId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
@@ -618,7 +604,6 @@ export class InstanceController {
   @Post(':instanceId/sendEphemeralConfirmationDelivered')
   @ApiOperation({summary: 'Send a delivery confirmation for an ephemeral message.'})
   @ApiResponse({
-    description: 'The delivery confirmation for an ephemeral message has been sent.',
     schema: {
       example: {
         instanceId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
@@ -657,7 +642,6 @@ export class InstanceController {
   @Post(':instanceId/sendEphemeralConfirmationRead')
   @ApiOperation({summary: 'Send a read confirmation for an ephemeral message.'})
   @ApiResponse({
-    description: 'The read confirmation for an ephemeral message has been sent.',
     schema: {
       example: {
         instanceId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
@@ -696,7 +680,6 @@ export class InstanceController {
   @Post(':instanceId/sendFile')
   @ApiOperation({summary: 'Send a file to a conversation.'})
   @ApiResponse({
-    description: 'File sent.',
     schema: {
       example: {
         instanceId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
@@ -765,7 +748,6 @@ export class InstanceController {
   @Post(':instanceId/sendImage')
   @ApiOperation({summary: 'Send an image to a conversation.'})
   @ApiResponse({
-    description: 'Image sent.',
     schema: {
       example: {
         instanceId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
@@ -816,7 +798,6 @@ export class InstanceController {
   @Post(':instanceId/sendLocation')
   @ApiOperation({summary: 'Send an location to a conversation.'})
   @ApiResponse({
-    description: 'Location sent.',
     schema: {
       example: {
         instanceId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
@@ -872,7 +853,6 @@ export class InstanceController {
   @Post(':instanceId/sendPing')
   @ApiOperation({summary: 'Send an ping to a conversation.'})
   @ApiResponse({
-    description: 'Ping sent.',
     schema: {
       example: {
         instanceId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
@@ -921,7 +901,6 @@ export class InstanceController {
   @Post(':instanceId/sendButtonAction')
   @ApiOperation({summary: 'Send a button action to a poll.'})
   @ApiResponse({
-    description: 'Button action sent.',
     schema: {
       example: {},
     },
@@ -954,7 +933,6 @@ export class InstanceController {
   @Post(':instanceId/sendButtonActionConfirmation')
   @ApiOperation({summary: 'Send a confirmation to a button action.'})
   @ApiResponse({
-    description: 'Confirmation sent.',
     schema: {
       example: {},
     },
@@ -987,7 +965,6 @@ export class InstanceController {
   @Post(':instanceId/sendReaction')
   @ApiOperation({summary: 'Send a reaction to a message.'})
   @ApiResponse({
-    description: 'Reaction sent.',
     schema: {
       example: {
         instanceId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
@@ -1029,7 +1006,6 @@ export class InstanceController {
   @Post(':instanceId/sendSessionReset')
   @ApiOperation({summary: 'Clear a conversation.'})
   @ApiResponse({
-    description: 'The conversation has been cleared.',
     schema: {
       example: {
         instanceId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
@@ -1069,7 +1045,6 @@ export class InstanceController {
   @Post(':instanceId/sendText')
   @ApiOperation({summary: 'Send a text message to a conversation.'})
   @ApiResponse({
-    description: 'Text message has been sent.',
     schema: {
       example: {
         instanceId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
@@ -1083,7 +1058,6 @@ export class InstanceController {
   @ApiResponse(status422description)
   @ApiResponse(status500description)
   @ApiBody({
-    description: '`legalHoldStatus` type can be `0` (unknown), `1` (disabled) or `2` (enabled).',
     type: InstanceTextOptions,
   })
   async sendText(
@@ -1155,7 +1129,6 @@ export class InstanceController {
   @Post(':instanceId/sendTyping')
   @ApiOperation({summary: 'Send a typing indicator to a conversation.'})
   @ApiResponse({
-    description: 'Typing indicator has been sent.',
     schema: {
       example: {
         instanceId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
@@ -1194,7 +1167,6 @@ export class InstanceController {
   @Post(':instanceId/updateText')
   @ApiOperation({summary: 'Update a text message in a conversation.'})
   @ApiResponse({
-    description: 'Text message has been updated.',
     schema: {
       example: {
         instanceId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',


### PR DESCRIPTION
It's already defined in the `summary`