### PR TITLE
fix: Allow multiple version of uuids for conversation Ids

### DIFF
--- a/src/instance/InstanceMuteOptions.ts
+++ b/src/instance/InstanceMuteOptions.ts
@@ -22,7 +22,7 @@ import {IsUUID, IsBoolean} from 'class-validator';
 
 export class InstanceMuteOptions {
   @ApiProperty({example: ''})
-  @IsUUID(4)
+  @IsUUID()
   conversationId!: string;
 
   @ApiProperty({example: false})

--- a/src/instance/InstancePingOptions.ts
+++ b/src/instance/InstancePingOptions.ts
@@ -28,7 +28,7 @@ export class InstancePingOptions {
   conversationDomain?: string;
 
   @ApiProperty({example: ''})
-  @IsUUID(4)
+  @IsUUID()
   conversationId!: string;
 
   @ApiPropertyOptional({example: false})

--- a/src/instance/InstanceReactionOptions.ts
+++ b/src/instance/InstanceReactionOptions.ts
@@ -29,7 +29,7 @@ export class InstanceReactionOptions {
   conversationDomain?: string;
 
   @ApiProperty({example: ''})
-  @IsUUID(4)
+  @IsUUID()
   conversationId!: string;
 
   @ApiPropertyOptional({

--- a/src/instance/InstanceTextOptions.ts
+++ b/src/instance/InstanceTextOptions.ts
@@ -147,7 +147,7 @@ export class InstanceTextOptions {
   conversationDomain?: string;
 
   @ApiProperty({example: ''})
-  @IsUUID(4)
+  @IsUUID()
   conversationId!: string;
 
   @ApiPropertyOptional({example: false})

--- a/src/instance/InstanceTypingOptions.ts
+++ b/src/instance/InstanceTypingOptions.ts
@@ -23,7 +23,7 @@ import {IsEnum, IsUUID} from 'class-validator';
 
 export class InstanceTypingOptions {
   @ApiProperty({example: ''})
-  @IsUUID(4)
+  @IsUUID()
   conversationId!: string;
 
   @ApiProperty({


### PR DESCRIPTION
Federated backends use UUID V5 while we check for only V4. 
This enables checking for any kind of UUID as the conversation ID