### PR TITLE
feat: add support for image metadata in `sendFile`

### DIFF
--- a/src/instance/InstanceController.ts
+++ b/src/instance/InstanceController.ts
@@ -825,6 +825,7 @@ export class InstanceController {
       const data = Buffer.from(body.data, 'base64');
       const fileContent: FileContent = {data};
       const metadata: FileMetaDataContent = {
+        image: body.image,
         length: data.length,
         name: body.fileName,
         type: body.type,

--- a/src/instance/InstanceFileOptions.ts
+++ b/src/instance/InstanceFileOptions.ts
@@ -51,6 +51,16 @@ class VideoMeta {
   width?: number;
 }
 
+class ImageMeta {
+  @ApiPropertyOptional({example: 0})
+  @IsNumber()
+  height!: number;
+
+  @ApiPropertyOptional({example: 0})
+  @IsNumber()
+  width!: number;
+}
+
 export class InstanceFileOptions {
   @ApiPropertyOptional()
   @ValidateNested()
@@ -117,4 +127,10 @@ export class InstanceFileOptions {
   @Type(() => VideoMeta)
   @IsOptional()
   video?: VideoMeta;
+
+  @ApiPropertyOptional()
+  @ValidateNested()
+  @Type(() => ImageMeta)
+  @IsOptional()
+  image?: ImageMeta;
 }


### PR DESCRIPTION
This PR extends the `sendFile` functionality to also accept and forward image metadata, which then allows to send images similar to `sendImage` but with all options of `sendFile`